### PR TITLE
new(broker): add broker logic between collectors and subscribers

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -1,0 +1,115 @@
+// Copyright 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
+
+	"github.com/alacuku/k8s-metadata/internal/events"
+	"github.com/alacuku/k8s-metadata/metadata"
+)
+
+// Broker receives events from the collectors and sends them to the subscribers.
+type Broker struct {
+	queue         <-chan events.Event
+	subscribers   *sync.Map
+	logger        logr.Logger
+	server        *grpc.Server
+	connectionsWg *sync.WaitGroup
+}
+
+// New returns a new Broker.
+func New(logger logr.Logger, queue <-chan events.Event, collectors map[string]chan<- string) (*Broker, error) {
+	subs := &sync.Map{}
+	group := &sync.WaitGroup{}
+	grpcServer := grpc.NewServer()
+	metadata.RegisterMetadataServer(grpcServer, metadata.New(logger.WithName("grpc-server"), subs, collectors, group))
+
+	return &Broker{
+		queue:         queue,
+		subscribers:   subs,
+		logger:        logger,
+		server:        grpcServer,
+		connectionsWg: group,
+	}, nil
+}
+
+// Start starts the grpc server and sends to subscribers the events received from the collectors.
+func (br *Broker) Start(ctx context.Context) error {
+	br.logger.Info("starting grpc server")
+	// Start the grpc server.
+	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", 45000))
+	if err != nil {
+		return fmt.Errorf("an error occurred whil creating listener for grpc server: %w", err)
+	}
+
+	br.logger.Info("starting", "grpc", "server")
+
+	serverError := make(chan error)
+	go func() {
+		serverError <- br.server.Serve(lis)
+	}()
+
+	for {
+		select {
+		case evt := <-br.queue:
+			for _, node := range evt.Nodes() {
+				// Get the grpc stream for the subscriber.
+				c, ok := br.subscribers.Load(node)
+				if !ok {
+					br.logger.Info("no stream found for", "node", node)
+					break
+				}
+				con, ok := c.(metadata.Connection)
+				if !ok {
+					br.logger.Error(fmt.Errorf("failed to cast subscriber connection %T", con), "node", node)
+					break
+				}
+
+				meta := &metadata.Event{
+					Reason: evt.Type(),
+					Metadata: &metadata.Fields{
+						Uid:       string(evt.GetMetadata().UID()),
+						Kind:      evt.GetMetadata().Kind(),
+						Name:      evt.GetMetadata().Name(),
+						Namespace: evt.GetMetadata().Namespace(),
+						Labels:    evt.GetMetadata().Labels(),
+					},
+					Refs: &metadata.References{Refs: evt.Refs()},
+				}
+				if err := con.Stream.Send(meta); err != nil {
+					con.Error <- err
+				}
+			}
+			// Wait for the context to be canceled. In that case we gracefully stop the broker.
+		case <-ctx.Done():
+			br.logger.Info("Shutdown signal received, waiting for grpc connections to close")
+			br.server.Stop()
+			br.connectionsWg.Wait()
+			br.logger.Info("All grpc connections closed")
+			return nil
+		// If the grpc server errors, the error is returned and the manager is stopped causing the application to exit.
+		case err := <-serverError:
+			br.logger.Error(err, "grpc server failed to start")
+			return err
+		}
+	}
+}

--- a/broker/doc.go
+++ b/broker/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package broker implements the broker logic.
+package broker

--- a/collectors/daemonset.go
+++ b/collectors/daemonset.go
@@ -16,6 +16,7 @@ package collectors
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/apps/v1"
@@ -44,6 +45,8 @@ type DaemonsetCollector struct {
 	Cache          events.GenericCache
 	GenericSource  source.Source
 	Name           string
+	SubscriberChan <-chan string
+	logger         logr.Logger
 }
 
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch
@@ -137,6 +140,75 @@ func (r *DaemonsetCollector) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, nil
 }
 
+// Start implements the runnable interface needed in order to handle the start/stop
+// using the manager. It starts go routines needed by the collector to interact with the
+// broker.
+func (r *DaemonsetCollector) Start(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	// it listens for new subscribers and sends the cached events to the
+	// subscriber received on the channel.
+	dispatchEventsOnSubcribe := func(ctx context.Context) {
+		wg.Add(1)
+		for {
+			select {
+			case sub := <-r.SubscriberChan:
+				r.logger.V(5).Info("Dispatching events", "subscriber", sub)
+				dispatch := func(res *events.GenericResource) {
+					// Check if the pod is related to the subscriber.
+					if _, ok := res.Nodes[sub]; ok {
+						r.Sink <- res.ToEvent(events.Added, []string{sub})
+					}
+				}
+				r.Cache.ForEach(dispatch)
+
+			case <-ctx.Done():
+				r.logger.V(5).Info("Stopping dispatcher on new subscribers")
+				wg.Done()
+				return
+			}
+		}
+	}
+
+	r.logger.Info("Starting event dispatcher for new subscribers")
+	// Start the dispatcher.
+	go dispatchEventsOnSubcribe(ctx)
+
+	// Wait for shutdown signal.
+	<-ctx.Done()
+	r.logger.Info("Waiting for event dispatcher to finish")
+	// Wait for goroutines to stop.
+	wg.Wait()
+	r.logger.Info("Dispatcher finished")
+
+	return nil
+}
+
+// TriggerEventsForSubscriber it listens for new subscribers and sends the cached events to the
+// subscriber received on the channel. It returns a channel, used to stop the go routine.
+func (r *DaemonsetCollector) TriggerEventsForSubscriber(subs <-chan string) chan bool {
+	done := make(chan bool)
+
+	go func() {
+		for {
+			select {
+			case subs := <-subs:
+				dispatch := func(res *events.GenericResource) {
+					// Check if the resources is related to the subscriber.
+					if _, ok := res.Nodes[subs]; ok {
+						r.Sink <- res.ToEvent(events.Added, []string{subs})
+					}
+				}
+				r.Cache.ForEach(dispatch)
+
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	return done
+}
+
 func (r *DaemonsetCollector) initMetrics() {
 	eventTotal.WithLabelValues(r.Name, labelAdded).Add(0)
 	eventTotal.WithLabelValues(r.Name, labelUpdated).Add(0)
@@ -172,6 +244,9 @@ func (r *DaemonsetCollector) Nodes(ctx context.Context, logger logr.Logger, meta
 // SetupWithManager sets up the controller with the Manager.
 func (r *DaemonsetCollector) SetupWithManager(mgr ctrl.Manager) error {
 	r.initMetrics()
+
+	// Set the generic logger to be used in other function then the reconcile loop.
+	r.logger = mgr.GetLogger().WithName(r.Name)
 
 	lc, err := newLogConstructor(mgr.GetLogger(), r.Name, resource.Daemonset)
 	if err != nil {

--- a/collectors/deployment.go
+++ b/collectors/deployment.go
@@ -16,6 +16,7 @@ package collectors
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/apps/v1"
@@ -44,6 +45,8 @@ type DeploymentCollector struct {
 	Cache          events.GenericCache
 	GenericSource  source.Source
 	Name           string
+	SubscriberChan <-chan string
+	logger         logr.Logger
 }
 
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
@@ -137,6 +140,49 @@ func (r *DeploymentCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, nil
 }
 
+// Start implements the runnable interface needed in order to handle the start/stop
+// using the manager. It starts go routines needed by the collector to interact with the
+// broker.
+func (r *DeploymentCollector) Start(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	// it listens for new subscribers and sends the cached events to the
+	// subscriber received on the channel.
+	dispatchEventsOnSubcribe := func(ctx context.Context) {
+		wg.Add(1)
+		for {
+			select {
+			case sub := <-r.SubscriberChan:
+				r.logger.V(5).Info("Dispatching events", "subscriber", sub)
+				dispatch := func(res *events.GenericResource) {
+					// Check if the pod is related to the subscriber.
+					if _, ok := res.Nodes[sub]; ok {
+						r.Sink <- res.ToEvent(events.Added, []string{sub})
+					}
+				}
+				r.Cache.ForEach(dispatch)
+
+			case <-ctx.Done():
+				r.logger.V(5).Info("Stopping dispatcher on new subscribers")
+				wg.Done()
+				return
+			}
+		}
+	}
+
+	r.logger.Info("Starting event dispatcher for new subscribers")
+	// Start the dispatcher.
+	go dispatchEventsOnSubcribe(ctx)
+
+	// Wait for shutdown signal.
+	<-ctx.Done()
+	r.logger.Info("Waiting for event dispatcher to finish")
+	// Wait for goroutines to stop.
+	wg.Wait()
+	r.logger.Info("Dispatcher finished")
+
+	return nil
+}
+
 func (r *DeploymentCollector) initMetrics() {
 	eventTotal.WithLabelValues(r.Name, labelAdded).Add(0)
 	eventTotal.WithLabelValues(r.Name, labelUpdated).Add(0)
@@ -172,6 +218,9 @@ func (r *DeploymentCollector) Nodes(ctx context.Context, logger logr.Logger, met
 // SetupWithManager sets up the controller with the Manager.
 func (r *DeploymentCollector) SetupWithManager(mgr ctrl.Manager) error {
 	r.initMetrics()
+
+	// Set the generic logger to be used in other function then the reconcile loop.
+	r.logger = mgr.GetLogger().WithName(r.Name)
 
 	lc, err := newLogConstructor(mgr.GetLogger(), r.Name, resource.Deployment)
 	if err != nil {

--- a/collectors/namespace.go
+++ b/collectors/namespace.go
@@ -16,6 +16,7 @@ package collectors
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +44,8 @@ type NamespaceCollector struct {
 	Cache          events.GenericCache
 	GenericSource  source.Source
 	Name           string
+	SubscriberChan <-chan string
+	logger         logr.Logger
 }
 
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
@@ -136,6 +139,48 @@ func (nc *NamespaceCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, nil
 }
 
+// Start implements the runnable interface needed in order to handle the start/stop
+// using the manager. It starts go routines needed by the collector to interact with the
+// broker.
+func (nc *NamespaceCollector) Start(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	// it listens for new subscribers and sends the cached events to the
+	// subscriber received on the channel.
+	dispatchEventsOnSubcribe := func(ctx context.Context) {
+		wg.Add(1)
+		for {
+			select {
+			case sub := <-nc.SubscriberChan:
+				nc.logger.V(5).Info("Dispatching events", "subscriber", sub)
+				dispatch := func(res *events.GenericResource) {
+					// Check if the pod is related to the subscriber.
+					if _, ok := res.Nodes[sub]; ok {
+						nc.Sink <- res.ToEvent(events.Added, []string{sub})
+					}
+				}
+				nc.Cache.ForEach(dispatch)
+
+			case <-ctx.Done():
+				nc.logger.V(5).Info("Stopping dispatcher on new subscribers")
+				wg.Done()
+				return
+			}
+		}
+	}
+
+	nc.logger.Info("Starting event dispatcher for new subscribers")
+	// Start the dispatcher.
+	go dispatchEventsOnSubcribe(ctx)
+
+	// Wait for shutdown signal.
+	<-ctx.Done()
+	nc.logger.Info("Waiting for event dispatcher to finish")
+	// Wait for goroutines to stop.
+	wg.Wait()
+	nc.logger.Info("Dispatcher finished")
+
+	return nil
+}
 func (nc *NamespaceCollector) initMetrics() {
 	eventTotal.WithLabelValues(nc.Name, labelAdded).Add(0)
 	eventTotal.WithLabelValues(nc.Name, labelUpdated).Add(0)
@@ -169,6 +214,9 @@ func (nc *NamespaceCollector) Nodes(ctx context.Context, logger logr.Logger, met
 // SetupWithManager sets up the controller with the Manager.
 func (nc *NamespaceCollector) SetupWithManager(mgr ctrl.Manager) error {
 	nc.initMetrics()
+
+	// Set the generic logger to be used in other function then the reconcile loop.
+	nc.logger = mgr.GetLogger().WithName(nc.Name)
 
 	lc, err := newLogConstructor(mgr.GetLogger(), nc.Name, resource.Namespace)
 	if err != nil {

--- a/collectors/replicaset.go
+++ b/collectors/replicaset.go
@@ -16,6 +16,7 @@ package collectors
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/apps/v1"
@@ -44,6 +45,8 @@ type ReplicasetCollector struct {
 	Cache          events.GenericCache
 	GenericSource  source.Source
 	Name           string
+	SubscriberChan <-chan string
+	logger         logr.Logger
 }
 
 //+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
@@ -137,6 +140,49 @@ func (r *ReplicasetCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, nil
 }
 
+// Start implements the runnable interface needed in order to handle the start/stop
+// using the manager. It starts go routines needed by the collector to interact with the
+// broker.
+func (r *ReplicasetCollector) Start(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	// it listens for new subscribers and sends the cached events to the
+	// subscriber received on the channel.
+	dispatchEventsOnSubcribe := func(ctx context.Context) {
+		wg.Add(1)
+		for {
+			select {
+			case sub := <-r.SubscriberChan:
+				r.logger.V(5).Info("Dispatching events", "subscriber", sub)
+				dispatch := func(res *events.GenericResource) {
+					// Check if the pod is related to the subscriber.
+					if _, ok := res.Nodes[sub]; ok {
+						r.Sink <- res.ToEvent(events.Added, []string{sub})
+					}
+				}
+				r.Cache.ForEach(dispatch)
+
+			case <-ctx.Done():
+				r.logger.V(5).Info("Stopping dispatcher on new subscribers")
+				wg.Done()
+				return
+			}
+		}
+	}
+
+	r.logger.Info("Starting event dispatcher for new subscribers")
+	// Start the dispatcher.
+	go dispatchEventsOnSubcribe(ctx)
+
+	// Wait for shutdown signal.
+	<-ctx.Done()
+	r.logger.Info("Waiting for event dispatcher to finish")
+	// Wait for goroutines to stop.
+	wg.Wait()
+	r.logger.Info("Dispatcher finished")
+
+	return nil
+}
+
 func (r *ReplicasetCollector) initMetrics() {
 	eventTotal.WithLabelValues(r.Name, labelAdded).Add(0)
 	eventTotal.WithLabelValues(r.Name, labelUpdated).Add(0)
@@ -171,6 +217,9 @@ func (r *ReplicasetCollector) Nodes(ctx context.Context, logger logr.Logger, met
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReplicasetCollector) SetupWithManager(mgr ctrl.Manager) error {
 	r.initMetrics()
+
+	// Set the generic logger to be used in other function then the reconcile loop.
+	r.logger = mgr.GetLogger().WithName(r.Name)
 
 	lc, err := newLogConstructor(mgr.GetLogger(), r.Name, resource.ReplicaSet)
 	if err != nil {

--- a/collectors/replicationcontroller.go
+++ b/collectors/replicationcontroller.go
@@ -16,6 +16,7 @@ package collectors
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +44,8 @@ type ReplicationcontrollerCollector struct {
 	Cache          events.GenericCache
 	GenericSource  source.Source
 	Name           string
+	SubscriberChan <-chan string
+	logger         logr.Logger
 }
 
 //+kubebuilder:rbac:groups=core,resources=replicationcontrollers,verbs=get;list;watch
@@ -136,6 +139,49 @@ func (r *ReplicationcontrollerCollector) Reconcile(ctx context.Context, req ctrl
 	return ctrl.Result{}, nil
 }
 
+// Start implements the runnable interface needed in order to handle the start/stop
+// using the manager. It starts go routines needed by the collector to interact with the
+// broker.
+func (r *ReplicationcontrollerCollector) Start(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	// it listens for new subscribers and sends the cached events to the
+	// subscriber received on the channel.
+	dispatchEventsOnSubcribe := func(ctx context.Context) {
+		wg.Add(1)
+		for {
+			select {
+			case sub := <-r.SubscriberChan:
+				r.logger.V(5).Info("Dispatching events", "subscriber", sub)
+				dispatch := func(res *events.GenericResource) {
+					// Check if the pod is related to the subscriber.
+					if _, ok := res.Nodes[sub]; ok {
+						r.Sink <- res.ToEvent(events.Added, []string{sub})
+					}
+				}
+				r.Cache.ForEach(dispatch)
+
+			case <-ctx.Done():
+				r.logger.V(5).Info("Stopping dispatcher on new subscribers")
+				wg.Done()
+				return
+			}
+		}
+	}
+
+	r.logger.Info("Starting event dispatcher for new subscribers")
+	// Start the dispatcher.
+	go dispatchEventsOnSubcribe(ctx)
+
+	// Wait for shutdown signal.
+	<-ctx.Done()
+	r.logger.Info("Waiting for event dispatcher to finish")
+	// Wait for goroutines to stop.
+	wg.Wait()
+	r.logger.Info("Dispatcher finished")
+
+	return nil
+}
+
 func (r *ReplicationcontrollerCollector) initMetrics() {
 	eventTotal.WithLabelValues(r.Name, labelAdded).Add(0)
 	eventTotal.WithLabelValues(r.Name, labelUpdated).Add(0)
@@ -171,6 +217,9 @@ func (r *ReplicationcontrollerCollector) Nodes(ctx context.Context, logger logr.
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReplicationcontrollerCollector) SetupWithManager(mgr ctrl.Manager) error {
 	r.initMetrics()
+
+	// Set the generic logger to be used in other function then the reconcile loop.
+	r.logger = mgr.GetLogger().WithName(r.Name)
 
 	lc, err := newLogConstructor(mgr.GetLogger(), r.Name, resource.ReplicationController)
 	if err != nil {

--- a/collectors/services.go
+++ b/collectors/services.go
@@ -16,6 +16,7 @@ package collectors
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +44,8 @@ type ServiceCollector struct {
 	Cache           events.GenericCache
 	EndpointsSource source.Source
 	Name            string
+	SubscriberChan  <-chan string
+	logger          logr.Logger
 }
 
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch
@@ -136,6 +139,49 @@ func (r *ServiceCollector) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	return ctrl.Result{}, nil
 }
 
+// Start implements the runnable interface needed in order to handle the start/stop
+// using the manager. It starts go routines needed by the collector to interact with the
+// broker.
+func (r *ServiceCollector) Start(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	// it listens for new subscribers and sends the cached events to the
+	// subscriber received on the channel.
+	dispatchEventsOnSubcribe := func(ctx context.Context) {
+		wg.Add(1)
+		for {
+			select {
+			case sub := <-r.SubscriberChan:
+				r.logger.V(5).Info("Dispatching events", "subscriber", sub)
+				dispatch := func(res *events.GenericResource) {
+					// Check if the pod is related to the subscriber.
+					if _, ok := res.Nodes[sub]; ok {
+						r.Sink <- res.ToEvent(events.Added, []string{sub})
+					}
+				}
+				r.Cache.ForEach(dispatch)
+
+			case <-ctx.Done():
+				r.logger.V(5).Info("Stopping dispatcher on new subscribers")
+				wg.Done()
+				return
+			}
+		}
+	}
+
+	r.logger.Info("Starting event dispatcher for new subscribers")
+	// Start the dispatcher.
+	go dispatchEventsOnSubcribe(ctx)
+
+	// Wait for shutdown signal.
+	<-ctx.Done()
+	r.logger.Info("Waiting for event dispatcher to finish")
+	// Wait for goroutines to stop.
+	wg.Wait()
+	r.logger.Info("Dispatcher finished")
+
+	return nil
+}
+
 func (r *ServiceCollector) initMetrics() {
 	eventTotal.WithLabelValues(r.Name, labelAdded).Add(0)
 	eventTotal.WithLabelValues(r.Name, labelUpdated).Add(0)
@@ -167,6 +213,9 @@ func (r *ServiceCollector) Nodes(ctx context.Context, logger logr.Logger, svc *c
 // SetupWithManager sets up the controller with the Manager.
 func (r *ServiceCollector) SetupWithManager(mgr ctrl.Manager) error {
 	r.initMetrics()
+
+	// Set the generic logger to be used in other function then the reconcile loop.
+	r.logger = mgr.GetLogger().WithName(r.Name)
 
 	lc, err := newLogConstructor(mgr.GetLogger(), r.Name, resource.Service)
 	if err != nil {

--- a/internal/fields/fields.go
+++ b/internal/fields/fields.go
@@ -104,13 +104,13 @@ type References map[string][]Reference
 
 // ToFlatMap return the references in a map where the key is the kind of the object for which the references
 // are saved. The value is slice containing all the types.UID for objects of the same kind as the key.
-func (r *References) ToFlatMap() map[string][]types.UID {
-	flatMap := make(map[string][]types.UID)
+func (r *References) ToFlatMap() map[string][]string {
+	flatMap := make(map[string][]string)
 
 	for key, val := range *r {
-		refs := make([]types.UID, len(val))
+		refs := make([]string, len(val))
 		for i := range val {
-			refs[i] = val[i].UID
+			refs[i] = string(val[i].UID)
 		}
 		flatMap[key] = refs
 	}


### PR DESCRIPTION
This PR introduces a simple version of the `broker`. It takes events from a queue and sends them to the subscribers interested in those events.