### PR TITLE
update(events): use a single resource type and cache for all k8s resources

### DIFF
--- a/internal/events/cache.go
+++ b/internal/events/cache.go
@@ -14,66 +14,9 @@
 
 package events
 
-import "sync"
-
-// PodCache a cache for pod resources.
-type PodCache struct {
-	sync.RWMutex
-	pods map[string]*PodResource
-}
-
-// NewPodCache creates a new PodCache.
-func NewPodCache() PodCache {
-	return PodCache{pods: make(map[string]*PodResource)}
-}
-
-// Add adds a new item to the cache if it does not exist. At the same time, when adding the item to the cache
-// we reset the information about the nodes to which we should send an "Added" event. Before calling the Add function
-// for a resource make sure that you have generated the "Added" event for the resource.
-func (pc *PodCache) Add(key string, value *PodResource) {
-	pc.Lock()
-	// Check if the resource already exists.
-	if _, ok := pc.pods[key]; !ok {
-		pc.pods[key] = value
-	}
-	// Do not track anymore the nodes for which we need to generate an "Added" event.
-	value.SetCreatedFor(nil)
-	pc.Unlock()
-}
-
-// Update updates an item in the cache. At the same time, when updating the item in the cache
-// we reset the information about the nodes to which we should send a "Modified" event. Before calling the Update function
-// for a resource make sure that you have generated the "Modified" event for the resource.
-func (pc *PodCache) Update(key string, value *PodResource) {
-	pc.Lock()
-	pc.pods[key] = value
-	// Do not track anymore the nodes for which we need to generate a "Modified" event.
-	value.SetModifiedFor(nil)
-	pc.Unlock()
-}
-
-// Delete deletes an item from the cache.
-func (pc *PodCache) Delete(key string) {
-	pc.Lock()
-	delete(pc.pods, key)
-	pc.Unlock()
-}
-
-// Get returns an item from the cache using the provided key.
-func (pc *PodCache) Get(key string) (*PodResource, bool) {
-	pc.RLock()
-	val, ok := pc.pods[key]
-	pc.RUnlock()
-	return val, ok
-}
-
-func (pc *PodCache) ForEach(apply func(resource *PodResource)) {
-	pc.RLock()
-	for _, pod := range pc.pods {
-		apply(pod)
-	}
-	pc.RUnlock()
-}
+import (
+	"sync"
+)
 
 // GenericCache for generic resources.
 type GenericCache struct {

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func main() {
 	podCollector := &collectors.PodCollector{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
-		Cache:           events.NewPodCache(),
+		Cache:           events.NewGenericCache(),
 		Name:            "pod-collector",
 		Queue:           queue,
 		ExternalSources: externalSrc,


### PR DESCRIPTION


The PodCache and GenericCache have been merged into a unique cache. The same has been done for PodResource and GenericResource. Doing so removes a lot of duplicated code and makes the project more maintainable.