### PR TITLE
refactor(collectors): rework dispatching logic used by collectors

### DIFF
--- a/collectors/daemonset.go
+++ b/collectors/daemonset.go
@@ -16,7 +16,6 @@ package collectors
 
 import (
 	"context"
-	"sync"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/apps/v1"
@@ -143,43 +142,7 @@ func (r *DaemonsetCollector) Reconcile(ctx context.Context, req ctrl.Request) (c
 // using the manager. It starts go routines needed by the collector to interact with the
 // broker.
 func (r *DaemonsetCollector) Start(ctx context.Context) error {
-	wg := sync.WaitGroup{}
-	// it listens for new subscribers and sends the cached events to the
-	// subscriber received on the channel.
-	dispatchEventsOnSubcribe := func(ctx context.Context) {
-		wg.Add(1)
-		for {
-			select {
-			case sub := <-r.SubscriberChan:
-				r.logger.V(5).Info("Dispatching events", "subscriber", sub)
-				dispatch := func(res *events.GenericResource) {
-					// Check if the pod is related to the subscriber.
-					if _, ok := res.Nodes[sub]; ok {
-						r.Queue.Push(res.ToEvent(events.Added, []string{sub}))
-					}
-				}
-				r.Cache.ForEach(dispatch)
-
-			case <-ctx.Done():
-				r.logger.V(5).Info("Stopping dispatcher on new subscribers")
-				wg.Done()
-				return
-			}
-		}
-	}
-
-	r.logger.Info("Starting event dispatcher for new subscribers")
-	// Start the dispatcher.
-	go dispatchEventsOnSubcribe(ctx)
-
-	// Wait for shutdown signal.
-	<-ctx.Done()
-	r.logger.Info("Waiting for event dispatcher to finish")
-	// Wait for goroutines to stop.
-	wg.Wait()
-	r.logger.Info("Dispatcher finished")
-
-	return nil
+	return dispatch(ctx, r.logger, r.SubscriberChan, r.Queue, &r.Cache)
 }
 
 func (r *DaemonsetCollector) initMetrics() {

--- a/collectors/deployment.go
+++ b/collectors/deployment.go
@@ -16,7 +16,6 @@ package collectors
 
 import (
 	"context"
-	"sync"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/apps/v1"
@@ -143,43 +142,7 @@ func (r *DeploymentCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 // using the manager. It starts go routines needed by the collector to interact with the
 // broker.
 func (r *DeploymentCollector) Start(ctx context.Context) error {
-	wg := sync.WaitGroup{}
-	// it listens for new subscribers and sends the cached events to the
-	// subscriber received on the channel.
-	dispatchEventsOnSubcribe := func(ctx context.Context) {
-		wg.Add(1)
-		for {
-			select {
-			case sub := <-r.SubscriberChan:
-				r.logger.V(5).Info("Dispatching events", "subscriber", sub)
-				dispatch := func(res *events.GenericResource) {
-					// Check if the pod is related to the subscriber.
-					if _, ok := res.Nodes[sub]; ok {
-						r.Queue.Push(res.ToEvent(events.Added, []string{sub}))
-					}
-				}
-				r.Cache.ForEach(dispatch)
-
-			case <-ctx.Done():
-				r.logger.V(5).Info("Stopping dispatcher on new subscribers")
-				wg.Done()
-				return
-			}
-		}
-	}
-
-	r.logger.Info("Starting event dispatcher for new subscribers")
-	// Start the dispatcher.
-	go dispatchEventsOnSubcribe(ctx)
-
-	// Wait for shutdown signal.
-	<-ctx.Done()
-	r.logger.Info("Waiting for event dispatcher to finish")
-	// Wait for goroutines to stop.
-	wg.Wait()
-	r.logger.Info("Dispatcher finished")
-
-	return nil
+	return dispatch(ctx, r.logger, r.SubscriberChan, r.Queue, &r.Cache)
 }
 
 func (r *DeploymentCollector) initMetrics() {

--- a/collectors/dispatch.go
+++ b/collectors/dispatch.go
@@ -1,0 +1,69 @@
+// Copyright 2023 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-logr/logr"
+
+	"github.com/alacuku/k8s-metadata/broker"
+	"github.com/alacuku/k8s-metadata/internal/events"
+)
+
+// Dispatch starts a go routing which waits for subscribers and dispatches the events to them. Events
+// are taken from the cache and sent through the queue. It does not return until the context is closed.
+func dispatch(ctx context.Context, logger logr.Logger,
+	subChan <-chan string, queue broker.Queue, cache *events.GenericCache) error {
+	wg := sync.WaitGroup{}
+	// it listens for new subscribers and sends the cached events to the
+	// subscriber received on the channel.
+	dispatchEventsOnSubcribe := func(ctx context.Context) {
+		wg.Add(1)
+		for {
+			select {
+			case sub := <-subChan:
+				logger.V(2).Info("Dispatching events", "subscriber", sub)
+				dispatch := func(res *events.GenericResource) {
+					// Check if the pod is related to the subscriber.
+					if _, ok := res.Nodes[sub]; ok {
+						queue.Push(res.ToEvent(events.Added, []string{sub}))
+					}
+				}
+				cache.ForEach(dispatch)
+				logger.V(2).Info("Events correctly dispatched", "subscriber", sub)
+
+			case <-ctx.Done():
+				logger.V(2).Info("Stopping dispatcher on new subscribers")
+				wg.Done()
+				return
+			}
+		}
+	}
+
+	logger.Info("Starting event dispatcher for new subscribers")
+	// Start the dispatcher.
+	go dispatchEventsOnSubcribe(ctx)
+
+	// Wait for shutdown signal.
+	<-ctx.Done()
+	logger.Info("Waiting for event dispatcher to finish")
+	// Wait for goroutines to stop.
+	wg.Wait()
+	logger.Info("Dispatcher finished")
+
+	return nil
+}

--- a/collectors/replicaset.go
+++ b/collectors/replicaset.go
@@ -16,7 +16,6 @@ package collectors
 
 import (
 	"context"
-	"sync"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/apps/v1"
@@ -143,43 +142,7 @@ func (r *ReplicasetCollector) Reconcile(ctx context.Context, req ctrl.Request) (
 // using the manager. It starts go routines needed by the collector to interact with the
 // broker.
 func (r *ReplicasetCollector) Start(ctx context.Context) error {
-	wg := sync.WaitGroup{}
-	// it listens for new subscribers and sends the cached events to the
-	// subscriber received on the channel.
-	dispatchEventsOnSubcribe := func(ctx context.Context) {
-		wg.Add(1)
-		for {
-			select {
-			case sub := <-r.SubscriberChan:
-				r.logger.V(5).Info("Dispatching events", "subscriber", sub)
-				dispatch := func(res *events.GenericResource) {
-					// Check if the pod is related to the subscriber.
-					if _, ok := res.Nodes[sub]; ok {
-						r.Queue.Push(res.ToEvent(events.Added, []string{sub}))
-					}
-				}
-				r.Cache.ForEach(dispatch)
-
-			case <-ctx.Done():
-				r.logger.V(5).Info("Stopping dispatcher on new subscribers")
-				wg.Done()
-				return
-			}
-		}
-	}
-
-	r.logger.Info("Starting event dispatcher for new subscribers")
-	// Start the dispatcher.
-	go dispatchEventsOnSubcribe(ctx)
-
-	// Wait for shutdown signal.
-	<-ctx.Done()
-	r.logger.Info("Waiting for event dispatcher to finish")
-	// Wait for goroutines to stop.
-	wg.Wait()
-	r.logger.Info("Dispatcher finished")
-
-	return nil
+	return dispatch(ctx, r.logger, r.SubscriberChan, r.Queue, &r.Cache)
 }
 
 func (r *ReplicasetCollector) initMetrics() {

--- a/collectors/replicationcontroller.go
+++ b/collectors/replicationcontroller.go
@@ -16,7 +16,6 @@ package collectors
 
 import (
 	"context"
-	"sync"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -142,43 +141,7 @@ func (r *ReplicationcontrollerCollector) Reconcile(ctx context.Context, req ctrl
 // using the manager. It starts go routines needed by the collector to interact with the
 // broker.
 func (r *ReplicationcontrollerCollector) Start(ctx context.Context) error {
-	wg := sync.WaitGroup{}
-	// it listens for new subscribers and sends the cached events to the
-	// subscriber received on the channel.
-	dispatchEventsOnSubcribe := func(ctx context.Context) {
-		wg.Add(1)
-		for {
-			select {
-			case sub := <-r.SubscriberChan:
-				r.logger.V(5).Info("Dispatching events", "subscriber", sub)
-				dispatch := func(res *events.GenericResource) {
-					// Check if the pod is related to the subscriber.
-					if _, ok := res.Nodes[sub]; ok {
-						r.Queue.Push(res.ToEvent(events.Added, []string{sub}))
-					}
-				}
-				r.Cache.ForEach(dispatch)
-
-			case <-ctx.Done():
-				r.logger.V(5).Info("Stopping dispatcher on new subscribers")
-				wg.Done()
-				return
-			}
-		}
-	}
-
-	r.logger.Info("Starting event dispatcher for new subscribers")
-	// Start the dispatcher.
-	go dispatchEventsOnSubcribe(ctx)
-
-	// Wait for shutdown signal.
-	<-ctx.Done()
-	r.logger.Info("Waiting for event dispatcher to finish")
-	// Wait for goroutines to stop.
-	wg.Wait()
-	r.logger.Info("Dispatcher finished")
-
-	return nil
+	return dispatch(ctx, r.logger, r.SubscriberChan, r.Queue, &r.Cache)
 }
 
 func (r *ReplicationcontrollerCollector) initMetrics() {

--- a/collectors/services.go
+++ b/collectors/services.go
@@ -16,7 +16,6 @@ package collectors
 
 import (
 	"context"
-	"sync"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -142,43 +141,7 @@ func (r *ServiceCollector) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 // using the manager. It starts go routines needed by the collector to interact with the
 // broker.
 func (r *ServiceCollector) Start(ctx context.Context) error {
-	wg := sync.WaitGroup{}
-	// it listens for new subscribers and sends the cached events to the
-	// subscriber received on the channel.
-	dispatchEventsOnSubcribe := func(ctx context.Context) {
-		wg.Add(1)
-		for {
-			select {
-			case sub := <-r.SubscriberChan:
-				r.logger.V(5).Info("Dispatching events", "subscriber", sub)
-				dispatch := func(res *events.GenericResource) {
-					// Check if the pod is related to the subscriber.
-					if _, ok := res.Nodes[sub]; ok {
-						r.Queue.Push(res.ToEvent(events.Added, []string{sub}))
-					}
-				}
-				r.Cache.ForEach(dispatch)
-
-			case <-ctx.Done():
-				r.logger.V(5).Info("Stopping dispatcher on new subscribers")
-				wg.Done()
-				return
-			}
-		}
-	}
-
-	r.logger.Info("Starting event dispatcher for new subscribers")
-	// Start the dispatcher.
-	go dispatchEventsOnSubcribe(ctx)
-
-	// Wait for shutdown signal.
-	<-ctx.Done()
-	r.logger.Info("Waiting for event dispatcher to finish")
-	// Wait for goroutines to stop.
-	wg.Wait()
-	r.logger.Info("Dispatcher finished")
-
-	return nil
+	return dispatch(ctx, r.logger, r.SubscriberChan, r.Queue, &r.Cache)
 }
 
 func (r *ServiceCollector) initMetrics() {


### PR DESCRIPTION
The dispatching logic lives in a dedicated function and each collector calls it in their Start function. A lot of duplicated code is removed.