### PR TITLE
fix(collector): services are correctly dispatched to subscribers

### DIFF
--- a/collectors/transformers.go
+++ b/collectors/transformers.go
@@ -37,7 +37,8 @@ var PodTransformer = func(logger logr.Logger) toolscache.TransformFunc {
 			return nil, err
 		}
 
-		pod.Status = corev1.PodStatus{}
+		podIP := pod.Status.PodIP
+		pod.Status = corev1.PodStatus{PodIP: podIP}
 		nodeName := pod.Spec.NodeName
 		pod.Spec = corev1.PodSpec{NodeName: nodeName}
 		pod.SetAnnotations(nil)

--- a/main.go
+++ b/main.go
@@ -272,6 +272,7 @@ func main() {
 		ServiceCollectorSource: svc,
 		PodCollectorSource:     pd,
 		Pods:                   make(map[string]map[string]struct{}),
+		ServicesName:           make(map[string]string),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create dispatcher for", "resource kind", resource.EndpointSlice)
 		os.Exit(1)


### PR DESCRIPTION
Endpointslices dispatcher triggered the service collector using the wrong name. The pod ip is now preserved during the transformation.