### PR TITLE
new(events): make "resource" self contained

### DIFF
--- a/pkg/events/cache.go
+++ b/pkg/events/cache.go
@@ -32,28 +32,20 @@ func NewCache() *Cache {
 	}
 }
 
-// Add adds a new item to the cache if it does not exist. When adding the item to the cache
-// we reset the information about the nodes to which we should send an "Added" event. Before calling the Add function
-// for a resource make sure that you have generated the "Added" event for the resource.
+// Add adds a new item to the cache if it does not exist.
 func (gc *Cache) Add(key string, value *Resource) {
 	gc.rwLock.Lock()
 	// Check if the resource already exists.
 	if _, ok := gc.resources[key]; !ok {
 		gc.resources[key] = value
 	}
-	// Do not track anymore the nodes for which we need to generate an "Added" event.
-	value.SetCreatedFor(nil)
 	gc.rwLock.Unlock()
 }
 
-// Update updates an item in the cache. At the same time, when updating the item in the cache
-// we reset the information about the nodes to which we should send a "Modified" event. Before calling the Update function
-// for a resource make sure that you have generated the "Modified" event for the resource.
+// Update updates an item in the cache.
 func (gc *Cache) Update(key string, value *Resource) {
 	gc.rwLock.Lock()
 	gc.resources[key] = value
-	// Do not track anymore the nodes for which we need to generate a "Modified" event.
-	value.SetModifiedFor(nil)
 	gc.rwLock.Unlock()
 }
 

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -244,6 +244,7 @@ func (g *Resource) ToEvents() []Event {
 			},
 			DestinationNodes: g.addedFor,
 		}
+		g.addedFor = nil
 	}
 
 	if len(g.modifiedFor) != 0 {
@@ -259,6 +260,7 @@ func (g *Resource) ToEvents() []Event {
 			},
 			DestinationNodes: g.modifiedFor,
 		}
+		g.modifiedFor = nil
 	}
 
 	if len(g.deletedFor) != 0 {
@@ -270,6 +272,7 @@ func (g *Resource) ToEvents() []Event {
 			},
 			DestinationNodes: g.deletedFor,
 		}
+		g.deletedFor = nil
 	}
 
 	return evts


### PR DESCRIPTION
The resource type uses internal variables to track the nodes for which an event has been generated. Those fields are now handled only by methods of resource type.