### PR TITLE
fix(dispatch): avoid deadlock at exit time

### DIFF
--- a/metadata/server.go
+++ b/metadata/server.go
@@ -105,8 +105,6 @@ func (s *Server) Watch(selector *Selector, stream Metadata_WatchServer) error {
 		s.logger.Error(err, "closing connection", "subscriber", selector.NodeName)
 	}
 
-	s.logger.Info("stream deleted", "subscriber", selector.NodeName)
-
 	// Unsubscribe from all the collectors.
 	s.subscribers.Delete(UID)
 	msg.Reason = subscriber.Unsubscribed
@@ -115,6 +113,7 @@ func (s *Server) Watch(selector *Selector, stream Metadata_WatchServer) error {
 			collector <- msg
 		}
 	}
+	s.logger.Info("stream deleted", "subscriber", selector.NodeName)
 	subscribers.Dec()
 	return err
 }

--- a/pkg/subscriber/types.go
+++ b/pkg/subscriber/types.go
@@ -88,3 +88,8 @@ func (gc *Subscribers) HasNode(node string) bool {
 	_, ok := gc.items[node]
 	return ok
 }
+
+// Len returns the number of subscribers.
+func (gc *Subscribers) Len() int {
+	return len(gc.items)
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area broker

> /area protocol-buffers

> /grafana-dashboard

/area collectors

> /area tests

> /area examples

**What this PR does / why we need it**:

When a sigterm is received the active goroutines exits, and the subscriber
connections are closed. When a subscriber connection is closed it sends
a message to the dispatcher goroutine saying that it is done. But if the
dispatcher goroutine does not retrieve the messages from the buffered channel
of length 1, causes the subscribers to hang. This fix ensures that the dispatcher
goroutines do not exit without waiting for all the subscriber's connections to be closed.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
