### PR TITLE
fix(e2e): discard system services during tests

### DIFF
--- a/test/e2e/k8s.go
+++ b/test/e2e/k8s.go
@@ -291,6 +291,12 @@ func (dpl *Deployer) ListServices(t testing.TestingT, writer io.Writer, node str
 
 	for i := range services {
 		opt.Namespace = services[i].Namespace
+
+		// Some system services do not have labels, meaning that are not serving regular pods.
+		if len(services[i].Spec.Selector) == 0 {
+			continue
+		}
+
 		pods, err := k8s.ListPodsE(t, opt, v1.ListOptions{
 			LabelSelector: makeLabelSelector(services[i].Spec.Selector),
 			FieldSelector: NodeFieldSelector + node,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/falco/blob/dev/CONTRIBUTING.md) file in the Falco repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area broker

> /area protocol-buffers

> /grafana-dashboard

> /area collectors

/area tests

> /area examples

**What this PR does / why we need it**:

Sometimes there could be system services that do not serve traffic to regular pods, hence having their `selector` to none. In this cases we just skip them.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
