### PR TITLE
chore(chart): align chart release workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,10 @@
 
 > /kind flaky-test
 
+> If this PR prepares a chart release, uncomment:
+
+> /kind chart-release
+
 **Any specific area of the project related to this PR?**
 
 > Uncomment one (or more) `/area <>` lines:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,14 @@ For general Falco contribution guidelines, including DCO sign-off, see the organ
 
 ## Helm Chart Contributions
 
-The k8s-metacollector chart source lives in this repository under [`chart/k8s-metacollector`](chart/k8s-metacollector). This repository is the source of truth for chart changes, chart version bumps, changelog entries, and generated chart docs.
+The k8s-metacollector chart source lives in [`chart/k8s-metacollector`](chart/k8s-metacollector). Published Falco charts live in [`falcosecurity/charts`](https://github.com/falcosecurity/charts), and Falco infrastructure syncs this chart there only when the chart version is bumped.
 
-Published Falco charts live in [`falcosecurity/charts`](https://github.com/falcosecurity/charts). After chart changes are merged here, Falco infrastructure opens or updates the matching chart release PR in `falcosecurity/charts`.
+Open k8s-metacollector chart issues and PRs in this repository; `falcosecurity/charts` receives the generated sync PR.
 
-PRs that change chart templates, values, release metadata, or the application version rendered by the chart must update [`chart/k8s-metacollector/Chart.yaml`](chart/k8s-metacollector/Chart.yaml) and [`chart/k8s-metacollector/CHANGELOG.md`](chart/k8s-metacollector/CHANGELOG.md) in this repository.
+- Regular chart PRs: do not bump [`chart/k8s-metacollector/Chart.yaml`](chart/k8s-metacollector/Chart.yaml); add the change under `## Unreleased` in [`chart/k8s-metacollector/CHANGELOG.md`](chart/k8s-metacollector/CHANGELOG.md).
+- Chart release PRs: use `/kind chart-release`, bump [`chart/k8s-metacollector/Chart.yaml`](chart/k8s-metacollector/Chart.yaml), and move the selected `## Unreleased` entries into the new version section. Entries not included in that release can stay under `## Unreleased`.
 
-Use SemVer for the chart `version`: major for breaking changes to values, rendered resources, or upgrade behavior; minor for backward-compatible chart features; patch for backward-compatible fixes or metadata changes. Set `appVersion` to the k8s-metacollector version rendered by the chart.
+Use SemVer for the chart `version`: major for breaking changes, minor for backward-compatible chart features, patch for fixes or metadata changes. Set `appVersion` to the k8s-metacollector version rendered by the chart when preparing a chart release.
 
 If chart values or chart documentation change, update [`chart/k8s-metacollector/README.gotmpl`](chart/k8s-metacollector/README.gotmpl) and regenerate [`chart/k8s-metacollector/README.md`](chart/k8s-metacollector/README.md).
 

--- a/chart/k8s-metacollector/CHANGELOG.md
+++ b/chart/k8s-metacollector/CHANGELOG.md
@@ -4,6 +4,8 @@
 This file documents all notable changes to `k8s-metacollector` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## Unreleased
+
 ## v0.3.0
 
 * Bump k8s-metacollector to version 0.1.2

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,6 @@
 remote: origin
 validate-maintainers: false
+check-version-increment: false
 target-branch: main
 chart-repos:
   - falcosecurity=https://falcosecurity.github.io/charts


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [CONTRIBUTING.md](../CONTRIBUTING.md).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

/kind documentation

> /kind tests

> /kind failing-test

> /kind feature

> /kind flaky-test

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area library

> /area broker

> /area protocol-buffers

> /area grafana-dashboard

> /area collectors

/area chart

> /area tests

> /area examples

**What this PR does / why we need it**:

Aligns the chart contribution workflow with the source-managed chart sync.

This PR:

- documents that chart issues and PRs should be handled in this source repo;
- documents the normal chart change flow and the chart release flow;
- adds the `Unreleased` changelog section used before a chart release is prepared;
- disables chart-testing version increment checks for normal chart PRs;
- updates the PR template with the optional `/kind chart-release` marker for release PRs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
