### PR TITLE
new(pkg/transport): close API server watch streams that go silent

### DIFF
--- a/cmd/collector/run/run.go
+++ b/cmd/collector/run/run.go
@@ -19,12 +19,8 @@ import (
 	"context"
 	"flag"
 	"os"
+	"time"
 
-	"github.com/falcosecurity/k8s-metacollector/broker"
-	"github.com/falcosecurity/k8s-metacollector/collectors"
-	"github.com/falcosecurity/k8s-metacollector/pkg/events"
-	"github.com/falcosecurity/k8s-metacollector/pkg/resource"
-	"github.com/falcosecurity/k8s-metacollector/pkg/subscriber"
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -35,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,6 +38,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/falcosecurity/k8s-metacollector/broker"
+	"github.com/falcosecurity/k8s-metacollector/collectors"
+	"github.com/falcosecurity/k8s-metacollector/pkg/events"
+	"github.com/falcosecurity/k8s-metacollector/pkg/resource"
+	"github.com/falcosecurity/k8s-metacollector/pkg/subscriber"
+	"github.com/falcosecurity/k8s-metacollector/pkg/transport"
 )
 
 var (
@@ -54,11 +56,12 @@ func init() {
 }
 
 type flags struct {
-	metricsAddr  string
-	probeAddr    string
-	brokerAddr   string
-	certFilePath string
-	keyFilePath  string
+	metricsAddr      string
+	probeAddr        string
+	brokerAddr       string
+	certFilePath     string
+	keyFilePath      string
+	watchIdleTimeout time.Duration
 }
 
 func (fl *flags) add(flags *pflag.FlagSet) {
@@ -67,6 +70,10 @@ func (fl *flags) add(flags *pflag.FlagSet) {
 	flags.StringVar(&fl.brokerAddr, "broker-bind-address", ":45000", "The address the broker endpoint binds to")
 	flags.StringVar(&fl.certFilePath, "broker-server-cert", "", "Cert file path for grpc server")
 	flags.StringVar(&fl.keyFilePath, "broker-server-key", "", "Key file path for grpc server")
+	flags.DurationVar(&fl.watchIdleTimeout, "watch-idle-timeout", 0,
+		"Maximum time a watch stream to the API server may stay silent before it is closed and re-established. "+
+			"Healthy watches receive bookmark events about every minute, so a silent stream is a dead stream. "+
+			"Disabled by default; set to a positive duration (e.g. 5m) to enable.")
 }
 
 type options struct {
@@ -121,14 +128,19 @@ func (opts *options) Run(ctx context.Context) {
 
 	setupLog := ctrl.Log.WithName("setup")
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+	if opts.watchIdleTimeout > 0 {
+		restConfig.Wrap(transport.NewWatchIdleTimeoutWrapper(opts.watchIdleTimeout))
+	}
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme,
 		Metrics: server.Options{
 			BindAddress: opts.metricsAddr,
 		},
 		HealthProbeBindAddress: opts.probeAddr,
 		Cache: cache.Options{
-			DefaultUnsafeDisableDeepCopy: ptr.To(true),
+			DefaultUnsafeDisableDeepCopy: new(true),
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.Pod{}: {
 					Transform: collectors.PodTransformer(setupLog),

--- a/collectors/metrics.go
+++ b/collectors/metrics.go
@@ -16,12 +16,13 @@
 package collectors
 
 import (
-	"github.com/falcosecurity/k8s-metacollector/pkg/consts"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/falcosecurity/k8s-metacollector/pkg/consts"
 )
 
 const (
@@ -61,9 +62,9 @@ func init() {
 func predicatesWithMetrics(collectorName, sourceName string, filter func(object client.Object) bool) predicate.Funcs {
 	createCounter := ingestedEvents.WithLabelValues(collectorName, sourceName, labelCreate)
 	createCounter.Add(0)
-	updateCounter := ingestedEvents.WithLabelValues(collectorName, sourceName, labelDelete)
+	updateCounter := ingestedEvents.WithLabelValues(collectorName, sourceName, labelUpdate)
 	updateCounter.Add(0)
-	deleteCounter := ingestedEvents.WithLabelValues(collectorName, sourceName, labelUpdate)
+	deleteCounter := ingestedEvents.WithLabelValues(collectorName, sourceName, labelDelete)
 	deleteCounter.Add(0)
 	genericCounter := ingestedEvents.WithLabelValues(collectorName, sourceName, labelGeneric)
 	genericCounter.Add(0)

--- a/pkg/transport/doc.go
+++ b/pkg/transport/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package transport provides HTTP transport wrappers for the Kubernetes client.
+package transport

--- a/pkg/transport/idle_timeout.go
+++ b/pkg/transport/idle_timeout.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// NewWatchIdleTimeoutWrapper returns a wrapper for an http.RoundTripper that
+// enforces an idle timeout on the response body of watch requests. If the API
+// server sends no data on a watch stream for longer than the timeout, the
+// stream is closed and the pending read fails, which causes the reflector to
+// re-establish the watch.
+//
+// This protects against watch streams that die silently: the TCP connection
+// stays healthy (HTTP/2 pings are answered), the server never closes the
+// response, but no events are delivered anymore. Informers survive such
+// streams in a degraded mode where updates are lost, which for this collector
+// means metadata for new pods is never delivered to subscribers.
+//
+// The API server sends bookmark events on watches roughly every minute
+// (reflectors request them by default), so a healthy watch stream is never
+// silent for more than a couple of minutes regardless of resource activity.
+func NewWatchIdleTimeoutWrapper(timeout time.Duration) func(http.RoundTripper) http.RoundTripper {
+	return func(rt http.RoundTripper) http.RoundTripper {
+		return &watchIdleTimeoutRoundTripper{delegate: rt, timeout: timeout}
+	}
+}
+
+type watchIdleTimeoutRoundTripper struct {
+	delegate http.RoundTripper
+	timeout  time.Duration
+}
+
+// RoundTrip implements http.RoundTripper, wrapping the response body of
+// successful watch requests with an idle timeout.
+func (w *watchIdleTimeoutRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := w.delegate.RoundTrip(req)
+	if err != nil || resp == nil || resp.Body == nil {
+		return resp, err
+	}
+	if resp.StatusCode == http.StatusOK && isWatchRequest(req) {
+		resp.Body = newIdleTimeoutBody(resp.Body, w.timeout)
+	}
+	return resp, nil
+}
+
+// WrappedRoundTripper returns the delegate round tripper. It implements
+// k8s.io/apimachinery/pkg/util/net.RoundTripperWrapper so that client-go can
+// unwrap the transport when needed.
+func (w *watchIdleTimeoutRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return w.delegate
+}
+
+func isWatchRequest(req *http.Request) bool {
+	return req.URL.Query().Get("watch") == "true"
+}
+
+// idleTimeoutBody closes the underlying response body if no data is received
+// for longer than the timeout. The timer is re-armed on every successful read.
+type idleTimeoutBody struct {
+	rc       io.ReadCloser
+	timer    *time.Timer
+	timeout  time.Duration
+	timedOut atomic.Bool
+}
+
+func newIdleTimeoutBody(rc io.ReadCloser, timeout time.Duration) *idleTimeoutBody {
+	b := &idleTimeoutBody{rc: rc, timeout: timeout}
+	b.timer = time.AfterFunc(timeout, func() {
+		b.timedOut.Store(true)
+		// Closing the body unblocks any pending Read with an error.
+		_ = b.rc.Close()
+	})
+	return b
+}
+
+// Read implements io.Reader.
+func (b *idleTimeoutBody) Read(p []byte) (int, error) {
+	n, err := b.rc.Read(p)
+	if err != nil {
+		if b.timedOut.Load() {
+			return n, fmt.Errorf("watch stream received no data for %s, closing it: %w", b.timeout, err)
+		}
+		return n, err
+	}
+	b.timer.Reset(b.timeout)
+	return n, nil
+}
+
+// Close implements io.Closer.
+func (b *idleTimeoutBody) Close() error {
+	b.timer.Stop()
+	return b.rc.Close()
+}

--- a/pkg/transport/idle_timeout_test.go
+++ b/pkg/transport/idle_timeout_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// streamHandler writes a chunk every interval for count chunks, then goes
+// silent until the client disconnects.
+func streamHandler(interval time.Duration, count int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		for range count {
+			time.Sleep(interval)
+			if _, err := w.Write([]byte("event\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+		// Go silent, keeping the connection open.
+		<-r.Context().Done()
+	}
+}
+
+func get(t *testing.T, timeout time.Duration, url string) *http.Response {
+	t.Helper()
+	client := &http.Client{Transport: NewWatchIdleTimeoutWrapper(timeout)(http.DefaultTransport)}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+func TestWatchStreamTimesOutWhenIdle(t *testing.T) {
+	srv := httptest.NewServer(streamHandler(10*time.Millisecond, 1))
+	defer srv.Close()
+
+	resp := get(t, 200*time.Millisecond, srv.URL+"?watch=true")
+	defer resp.Body.Close()
+
+	start := time.Now()
+	data, err := io.ReadAll(resp.Body)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "watch stream received no data")
+	// The chunk sent before the stream went idle must have been received.
+	require.Equal(t, "event\n", string(data))
+	// The read must have failed roughly at the idle timeout, not immediately
+	// and not at some larger overall deadline.
+	require.WithinDuration(t, start.Add(230*time.Millisecond), time.Now(), 150*time.Millisecond)
+}
+
+func TestWatchStreamStaysOpenWhileDataFlows(t *testing.T) {
+	// Chunks arrive every 50ms, idle timeout is 200ms: the timer must be
+	// re-armed on every read and the stream must survive well past the
+	// timeout as long as data keeps flowing.
+	srv := httptest.NewServer(streamHandler(50*time.Millisecond, 10))
+	defer srv.Close()
+
+	resp := get(t, 200*time.Millisecond, srv.URL+"?watch=true")
+	defer resp.Body.Close()
+
+	buf := make([]byte, 6)
+	received := 0
+	for received < 10 {
+		_, err := io.ReadFull(resp.Body, buf)
+		require.NoError(t, err)
+		received++
+	}
+}
+
+func TestNonWatchRequestsAreNotWrapped(t *testing.T) {
+	srv := httptest.NewServer(streamHandler(10*time.Millisecond, 2))
+	defer srv.Close()
+
+	resp := get(t, 200*time.Millisecond, srv.URL)
+	defer resp.Body.Close()
+	require.IsType(t, &http.Response{}, resp)
+	_, wrapped := any(resp.Body).(*idleTimeoutBody)
+	require.False(t, wrapped)
+}
+
+func TestExplicitCloseStopsTimer(t *testing.T) {
+	srv := httptest.NewServer(streamHandler(10*time.Millisecond, 1))
+	defer srv.Close()
+
+	resp := get(t, 50*time.Millisecond, srv.URL+"?watch=true")
+	require.NoError(t, resp.Body.Close())
+	// Give a fired timer a chance to run; closing again must not panic and
+	// the body must not report a timeout.
+	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, resp.Body.Close())
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area collectors

/area library

**What this PR does / why we need it**:

Watch streams to the API server can die silently: the TCP connection stays healthy (HTTP/2 pings are answered, so client-go's transport-level health checks don't fire) and the server never closes the response, but no events are delivered anymore. Informers survive such streams in a degraded mode where updates are lost. For the metacollector this means metadata for **new pods** is never delivered to subscribers, and falco resolves all `k8smeta.*` fields as `<NA>` until the process is restarted — with no error anywhere (probes green, no log lines, gRPC subscribers connected).

We hit this in production repeatedly (full evidence, metrics history, and a goroutine dump in #186): each informer independently loses MODIFIED events at its jittered ~10h resync/relist boundary, while ADDED/DELETED keep flowing via relists.

This PR adds a transport wrapper that enforces an idle timeout on watch response bodies: if a watch stream delivers no data for longer than `--watch-idle-timeout` (default `5m`, `0` disables), the body is closed, the pending read fails, and the reflector re-establishes the watch. Reflectors request bookmark events, which the API server sends about every minute, so a healthy watch is never silent for more than a couple of minutes regardless of resource activity — the 5m default cannot misfire on a quiet cluster.

A second commit fixes a small metrics bug found while debugging this: the `update`/`delete` label values in `predicatesWithMetrics` are swapped (`UpdateFunc` increments the counter labeled `type="delete"` and vice versa), so `meta_collector_collector_event_api_server_received` reported inverted data by type. The bundled Grafana dashboard does not group by `type`, so it is unaffected.

**Which issue(s) this PR fixes**:

Fixes #186

**Special notes for your reviewer**:

- The wrapper only touches requests with `watch=true` and status 200; everything else passes through untouched. It implements `WrappedRoundTripper()` so client-go can still unwrap the transport.
- The idle timer is re-armed on every successful read and stopped on normal close; a timed-out read surfaces as `watch stream received no data for <timeout>, closing it: <underlying error>` in the reflector's usual watch-retry logging.
- Unit tests cover: timeout on a silent stream, timer re-arming while data flows, non-watch requests not being wrapped, and explicit close stopping the timer.
- This is deliberately a mitigation at the metacollector level: the underlying dead-watch behavior lives below (client-go/transport; see also kubernetes-sigs/controller-runtime#3428, same symptom class), but the metacollector is unusually exposed because falco's k8smeta plugin depends on continuous update delivery and the failure is otherwise invisible.
