### PR TITLE
fix(collectors): keep resourceVersion in cached objects to unbreak update delivery on client-go >= 0.33

### DIFF
--- a/collectors/partialObjectMetadata.go
+++ b/collectors/partialObjectMetadata.go
@@ -236,7 +236,7 @@ func (r *ObjectMetaCollector) objFieldsHandler(logger logr.Logger, res *events.R
 	}
 
 	// Remove unused meta fields
-	metaUnused := []string{"creationTimestamp", "ownerReferences"}
+	metaUnused := []string{"creationTimestamp", "ownerReferences", "resourceVersion"}
 	meta := objUn["metadata"]
 	metaMap := meta.(map[string]any)
 	for _, key := range metaUnused {

--- a/collectors/pod.go
+++ b/collectors/pod.go
@@ -326,7 +326,7 @@ func (pc *PodCollector) objFieldsHandler(logger logr.Logger, res *events.Resourc
 	}
 
 	// Remove unused meta fields.
-	metaUnused := []string{"creationTimestamp", "ownerReferences"}
+	metaUnused := []string{"creationTimestamp", "ownerReferences", "resourceVersion"}
 	meta := podUn["metadata"]
 	metaMap := meta.(map[string]any)
 	for _, key := range metaUnused {

--- a/collectors/services.go
+++ b/collectors/services.go
@@ -210,7 +210,7 @@ func (r *ServiceCollector) ObjFieldsHandler(logger logr.Logger, evt *events.Reso
 	}
 
 	// Remove unused meta fields
-	metaUnused := []string{"creationTimestamp", "ownerReferences"}
+	metaUnused := []string{"creationTimestamp", "ownerReferences", "resourceVersion"}
 
 	meta := svcUn["metadata"]
 	metaMap := meta.(map[string]any)

--- a/collectors/transformers.go
+++ b/collectors/transformers.go
@@ -106,7 +106,13 @@ func filterOutMetaFields(meta *metav1.ObjectMeta) {
 	meta.ManagedFields = nil
 	meta.Annotations = nil
 	meta.Finalizers = nil
-	meta.ResourceVersion = ""
+	// ResourceVersion is deliberately kept: since the InOrderInformers
+	// refactor (client-go >= 0.33), sharedIndexInformer.OnUpdate treats an
+	// update whose resourceVersion equals the cached one as a resync-only
+	// event; storing objects with a blanked resourceVersion makes every real
+	// update compare equal and silently stop reaching event handlers once the
+	// listener's initial syncing state expires at the first resync check
+	// (~SyncPeriod, default 10h). See #186.
 	meta.DeletionTimestamp = nil
 	meta.Generation = 0
 	meta.DeletionGracePeriodSeconds = nil


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area collectors

**What this PR does / why we need it**:

Root cause of #186, confirmed on a live cluster with wire-level and instrumented-build evidence.

`filterOutMetaFields` blanks `metadata.resourceVersion` before objects are stored in the informer cache. Since the `InOrderInformers` refactor (client-go >= 0.33, feature gate default-on), `sharedIndexInformer.OnUpdate` no longer receives the delta type; it classifies an update as a resync-only notification **by comparing resourceVersions**:

```go
// Events that didn't change resourceVersion are treated as resync events
// and only propagated to listeners that requested resync
isSync = accessor.GetResourceVersion() == oldAccessor.GetResourceVersion()
```

With every cached object holding `resourceVersion == ""`, every real MODIFIED event compares equal (`"" == ""`) and is classified as sync. Listeners initially start in the syncing set, so everything works — until the first resync check (jittered `SyncPeriod`, default 10h) flips each listener to non-syncing. From that moment, **all updates are silently dropped** for that informer: adds/deletes keep flowing (no isSync gate), the store stays fresh, nothing is logged, health probes stay green. New pods then never become resolvable and falco's k8smeta plugin reports `<NA>` for all pods created after the freeze, forever, until the process restarts — which resets the listeners and buys another ~10h. This matches the per-informer staggered 9–11h freeze onsets we measured (each informer has its own jittered resync period).

The fix keeps `resourceVersion` in the stored objects and instead strips it at the metadata marshal sites (`objFieldsHandler`/equivalents), so the payloads sent to subscribers and the change-detection hashes are byte-identical to today — no event-volume change, no behavioral change other than updates actually being delivered.

**Which issue(s) this PR fixes**:

Fixes #186

**Special notes for your reviewer**:

- Verified the classified-as-sync mechanism against client-go v0.35.2 and v0.36.1 sources; both FIFO implementations (legacy `DeltaFIFO` and `RealFIFO`) route through the same RV-comparing `OnUpdate`, so disabling the `InOrderInformers` feature gates does *not* mitigate — the transform fix is the only remedy.
- We are also filing a kubernetes/kubernetes issue: transforms that blank `resourceVersion` (a common memory-saving practice) now silently break update delivery for all long-resync listeners, with no error surfaced anywhere.
- A verification build of this fix is running in the production cluster where the bug reproduced at 9–11h on every process lifetime; I'll report the outcome on the issue after it passes the window.
